### PR TITLE
公開鍵一覧を取得するときのlatencyを計測する

### DIFF
--- a/gae_sandbox/src/metadata/handler.go
+++ b/gae_sandbox/src/metadata/handler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/lestrrat/go-jwx/jwk"
@@ -78,11 +79,15 @@ func Verify(w http.ResponseWriter, r *http.Request) {
 			return nil, err
 		}
 
+		start := time.Now()
 		set, err := jwk.Fetch("https://www.googleapis.com/oauth2/v3/certs")
 		if err != nil {
 			log.Printf("cannot get fetch key set. err: %v", err)
 			return nil, err
 		}
+		end := time.Now()
+		d := end.Sub(start)
+		log.Printf("duration: %v", d)
 
 		keyID, ok := token.Header["kid"].(string)
 		if !ok {


### PR DESCRIPTION
## これは何か？
#1 の実装において jwt の検証時に `https://www.googleapis.com/oauth2/v3/certs` を叩いて鍵一覧を取得します。
その際にこの鍵を取得するスピードを計測しました。

## 手順
1. /metadata でトークンを取得
2. /verify での検証時に時刻を計算します。


## 結果

```
1回目 ... 445.511615ms
2回目 ... 49.390533ms
3回目 ... 39.678731ms
```