### PR TITLE
add race conditions

### DIFF
--- a/go_sandbox/src/raceTest/go.mod
+++ b/go_sandbox/src/raceTest/go.mod
@@ -1,0 +1,3 @@
+module github.com/emahiro/raceTest
+
+go 1.13

--- a/go_sandbox/src/raceTest/main.go
+++ b/go_sandbox/src/raceTest/main.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+var m = make(map[string]int64, 0)
+
+func main() {
+	fmt.Printf("test")
+}
+
+func race(key string, val int64) {
+	fmt.Printf("key = %v, val = %v\n", key, val)
+	m[key] = val
+	fmt.Printf("m = %v\n", m)
+}

--- a/go_sandbox/src/raceTest/main.go
+++ b/go_sandbox/src/raceTest/main.go
@@ -1,14 +1,22 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
-var m = make(map[string]int64, 0)
+var (
+	m  = make(map[string]int64, 0)
+	mu = sync.Mutex{}
+)
 
 func main() {
 	fmt.Printf("test")
 }
 
 func race(key string, val int64) {
+	mu.Lock()
+	defer mu.Unlock()
 	fmt.Printf("key = %v, val = %v\n", key, val)
 	m[key] = val
 	fmt.Printf("m = %v\n", m)

--- a/go_sandbox/src/raceTest/main_test.go
+++ b/go_sandbox/src/raceTest/main_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+import "sync"
+
+func TestRace(t *testing.T) {
+	itr := []int64{1, 2, 3}
+	wg := sync.WaitGroup{}
+	wg.Add(len(itr))
+	for _, i := range itr {
+		i := i
+		go func(k string, v int64) {
+			race(k, v)
+			wg.Done()
+		}("test", i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## これは何か？

Go で意図的に race conditions を発生させるサンプルです。
実装で `concurrent map writes` が発生するコードを仕込んでいるので test にて3並行処理を行い実際に `concurrent map writes` が発生するコードを作ります。

```sh
go test ./... -v
=== RUN   TestRace
fatal error: concurrent map writes

# 略
```

毎回ではないですが、競合状態を引き起こすテストになってます。

また race コンディションもチェックします。

```sh
go test ./... -race
key = test, val = 1
key = test, val = 3
m = map[test:1]
==================
WARNING: DATA RACE

# 略
```

意図通り発生します。