### PR TITLE
テストサーバーを立ち上げるパターンとAPIのmock のパターンを書いてみた

### DIFF
--- a/go_sandbox/httpmockExample/go.mod
+++ b/go_sandbox/httpmockExample/go.mod
@@ -1,0 +1,3 @@
+module github.com/emahiro/httpmockExample
+
+go 1.13

--- a/go_sandbox/mockServerPattern/Makefile
+++ b/go_sandbox/mockServerPattern/Makefile
@@ -1,0 +1,9 @@
+start: start1 | start2
+
+.PHONY: start1
+start1:
+	@go run main.go
+
+.PHONY: start2
+start2:
+	@go run cmd/run-server/main.go

--- a/go_sandbox/mockServerPattern/cmd/run-server/main.go
+++ b/go_sandbox/mockServerPattern/cmd/run-server/main.go
@@ -21,7 +21,7 @@ func main() {
 			w.Write([]byte("enexpected request"))
 			return
 		}
-
+		fmt.Println("test")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(fmt.Sprintf("hello at port: %d", port)))
 	})

--- a/go_sandbox/mockServerPattern/cmd/run-server/main.go
+++ b/go_sandbox/mockServerPattern/cmd/run-server/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+var port = 8081
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("enexpected request"))
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(fmt.Sprintf("hello at port: %d", port)))
+	})
+
+	s := &http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: mux,
+	}
+
+	go func() {
+		log.Fatal(s.ListenAndServe())
+	}()
+
+	quit := make(chan os.Signal)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	m := <-quit
+	log.Printf("received signal %v. start shutdown server...", m)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := s.Shutdown(ctx); err != nil {
+		log.Fatalf("failed to shutdown gracefully. err: %v", err)
+	}
+
+	log.Println("success to shutdown gracefully.")
+	os.Exit(0)
+}

--- a/go_sandbox/mockServerPattern/go.mod
+++ b/go_sandbox/mockServerPattern/go.mod
@@ -1,0 +1,3 @@
+module github.com/emahiro/mockServerPattern
+
+go 1.13

--- a/go_sandbox/mockServerPattern/go.mod
+++ b/go_sandbox/mockServerPattern/go.mod
@@ -1,3 +1,5 @@
 module github.com/emahiro/mockServerPattern
 
 go 1.13
+
+require github.com/jarcoal/httpmock v1.0.4

--- a/go_sandbox/mockServerPattern/go.sum
+++ b/go_sandbox/mockServerPattern/go.sum
@@ -1,0 +1,2 @@
+github.com/jarcoal/httpmock v1.0.4 h1:jp+dy/+nonJE4g4xbVtl9QdrUNbn6/3hDT5R4nDIZnA=
+github.com/jarcoal/httpmock v1.0.4/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=

--- a/go_sandbox/mockServerPattern/main.go
+++ b/go_sandbox/mockServerPattern/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+var port = 8080
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello"))
+	})
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: mux,
+	}
+
+	fmt.Println("start server....")
+	go func() {
+		if err := server.ListenAndServe(); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGTERM, syscall.SIGINT)
+	log.Printf("signal %d received. shutdown gracefully.", <-quit)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := server.Shutdown(ctx); err != nil {
+		log.Fatalf("failed to shutdown gracefully. err: %v", err)
+	}
+
+	log.Printf("shutdown server....")
+	os.Exit(0)
+}

--- a/go_sandbox/mockServerPattern/main.go
+++ b/go_sandbox/mockServerPattern/main.go
@@ -19,6 +19,7 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("hello"))
 	})
+	mux.Handle("/user", &userHandler{})
 
 	server := &http.Server{
 		Addr:    fmt.Sprintf(":%d", port),
@@ -45,4 +46,16 @@ func main() {
 
 	log.Printf("shutdown server....")
 	os.Exit(0)
+}
+
+type userHandler struct{}
+
+func (h *userHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("unexpected method"))
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("user handler"))
 }

--- a/go_sandbox/mockServerPattern/main_test.go
+++ b/go_sandbox/mockServerPattern/main_test.go
@@ -1,0 +1,7 @@
+package main
+
+import "testing"
+
+func TestMain(m *testing.M) {
+	m.Run()
+}

--- a/go_sandbox/mockServerPattern/main_test.go
+++ b/go_sandbox/mockServerPattern/main_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/jarcoal/httpmock"
 )
 
 func TestPlainServerMock(t *testing.T) {
@@ -75,6 +77,40 @@ func Test_userHandlerMock(t *testing.T) {
 
 	client := http.DefaultClient
 	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("err: status code is %d", res.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("%s", string(b))
+}
+
+func TestAnotherServerMock(t *testing.T) {
+	httpmock.RegisterResponder(http.MethodGet, "/", func(r *http.Request) (*http.Response, error) {
+		r.URL.Scheme = "http"
+		r.URL.Host = "localhost:8081"
+		r.URL.Path = ""
+		return http.DefaultTransport.RoundTrip(r)
+	})
+
+	client := &http.Client{
+		Transport: httpmock.DefaultTransport,
+	}
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go_sandbox/mockServerPattern/main_test.go
+++ b/go_sandbox/mockServerPattern/main_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
@@ -115,6 +116,52 @@ func TestAnotherServerMock(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("err: status code is %d", res.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("%s", string(b))
+}
+
+func TestAnotherServerMockWithTestServer(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("unexpected method"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test server response is ok"))
+	}))
+	defer ts.Close()
+
+	httpmock.RegisterResponder(http.MethodGet, "/", func(r *http.Request) (*http.Response, error) {
+		u, err := url.Parse(ts.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		r.URL = u
+		return http.DefaultTransport.RoundTrip(r)
+	})
+
+	client := &http.Client{
+		Transport: httpmock.DefaultTransport,
+	}
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	res, err := client.Do(req)
 	if err != nil {
 		t.Fatal(err)

--- a/go_sandbox/mockServerPattern/main_test.go
+++ b/go_sandbox/mockServerPattern/main_test.go
@@ -1,7 +1,98 @@
 package main
 
-import "testing"
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
-func TestMain(m *testing.M) {
-	m.Run()
+func TestPlainServerMock(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test"))
+	}))
+	defer ts.Close()
+
+	client := http.DefaultClient
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	if res != nil && res.StatusCode != http.StatusOK {
+		t.Fatalf("err: status code: %v", res.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("%s", string(b))
+}
+
+func Test_userHandler(t *testing.T) {
+	ts := httptest.NewServer(&userHandler{})
+	defer ts.Close()
+
+	client := http.DefaultClient
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("err: status code is %d", res.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("%s", string(b))
+}
+
+func Test_userHandlerMock(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("user handler test"))
+	}))
+	defer ts.Close()
+
+	client := http.DefaultClient
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("err: status code is %d", res.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("%s", string(b))
 }


### PR DESCRIPTION
#  Motivation

httptest と httpmock の使い分け、特に httptest はテストの中で別のサーバーを複数台立ち上げることができそうなのでもし立ち上げた場合にその内部で API 周りの処理を書いてしまえばテストを走らせるだけでAPIの疎通テストと同等のことができるのでは？と考えてそのパターンだしを実際のテストの実装込みで行ってみた。
