### PR TITLE
using http default transport in httpmock

### DIFF
--- a/go_sandbox/mockServerPattern/main_test.go
+++ b/go_sandbox/mockServerPattern/main_test.go
@@ -179,3 +179,94 @@ func TestAnotherServerMockWithTestServer(t *testing.T) {
 
 	t.Logf("%s", string(b))
 }
+
+func TestAnotherServerMockWithTestServerURLByHTTPDefaultTransport(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("unexpected method"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test server response is ok via http default transport in httpmock"))
+	}))
+	defer ts.Close()
+
+	httpmock.RegisterResponder(http.MethodGet, "/", func(r *http.Request) (*http.Response, error) {
+		client := &http.Client{
+			Transport: new(http.Transport),
+		}
+		url, err := url.Parse(ts.URL)
+		if err != nil {
+			return nil, err
+		}
+		r.URL = url
+		return client.Do(r)
+	})
+
+	client := &http.Client{
+		Transport: httpmock.DefaultTransport,
+	}
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("err: status code is %d", res.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("%s", string(b))
+}
+
+func TestAnotherServerMockWithTestServerTrasport(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("unexpected method"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test server response is ok in using test server http default transport"))
+	}))
+	defer ts.Close()
+
+	httpmock.RegisterResponder(http.MethodGet, ts.URL, func(r *http.Request) (*http.Response, error) {
+		clinet := &http.Client{
+			Transport: new(http.Transport),
+		}
+		return clinet.Do(r)
+	})
+
+	client := &http.Client{}
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("err: status code is %d", res.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("%s", string(b))
+}


### PR DESCRIPTION
#11 の続き。
HTTP Client に HTTP mock の Transport を指定せずに 新しく Transport を指定することで RoundTrip できるようにする。