### PR TITLE
add: sortFunc の挙動の研究

### DIFF
--- a/go-iter-sample/main.go
+++ b/go-iter-sample/main.go
@@ -2,17 +2,49 @@ package main
 
 import (
 	"fmt"
-
-	"github.com/emahiro/il/go-iter-sample/list"
+	"maps"
+	"slices"
 )
 
-func main() {
-	var l list.List[int]
-	l.Push(1)
-	l.Push(2)
-	l.Push(3)
+type taple struct {
+	a int
+	b string
+}
 
-	for list := range l.All() {
-		fmt.Println(list.Value())
+func main() {
+	num := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	for i := range slices.Chunk(num, 3) {
+		fmt.Println(i)
 	}
+
+	m := map[string]int{"a": 1, "b": 2, "c": 3}
+	for k, v := range maps.All(m) {
+		fmt.Println(k, v)
+	}
+
+	// random slice order
+	arr := []int{3, 1, 2, 4, 5}
+	fmt.Println(slices.IsSorted(arr))
+	slices.SortFunc(arr, func(a, b int) int {
+		if a < b {
+			return -1
+		} else if a > b {
+			return 1
+		}
+		return 0
+	})
+	fmt.Println(arr)
+
+	// sort の種類を設定してみる
+	taples1 := []taple{{3, "dd"}, {1, "a"}, {3, "cc"}, {3, "ff"}, {2, "b"}, {4, "ee"}}
+	s1 := slices.SortedFunc(slices.Values(taples1), func(a, b taple) int {
+		return a.a - b.a
+	})
+	fmt.Println(s1)
+
+	taples2 := []taple{{3, "dd"}, {1, "a"}, {3, "cc"}, {3, "ff"}, {2, "b"}, {4, "ee"}}
+	s2 := slices.SortedStableFunc(slices.Values(taples2), func(a, b taple) int {
+		return a.a - b.a
+	})
+	fmt.Println(s2)
 }


### PR DESCRIPTION
# 概要
Go1.23 から追加された slices package の中にある以下の2つのメソッドについて調べてみた。

- https://pkg.go.dev/slices#SortedFunc
- https://pkg.go.dev/slices#SortedFunc

# sort における stable とは

ChatGPT にきいてみた。

---

~ 以下 ChatGPT による回答 ~

ソートにおける「stable（安定）」とは、ソートされた後も、元の順序が保持される性質を指します。

具体的には、ソートする際に、同じ値を持つ要素が複数ある場合、それらの要素の相対的な順序がソート後も変わらないことを意味します。例えば、リストの中に同じ値を持つ要素AとBがあり、ソート前にAがBの前にあったとします。安定なソートを行った場合、ソート後もAはBの前に残ります。

### 例:
以下に、安定なソートと不安定なソートの違いを示します。

#### ソート前
```
[(3, 'a'), (1, 'b'), (2, 'c'), (3, 'd')]
```

#### 安定なソート後 (数値でソート)
```
[(1, 'b'), (2, 'c'), (3, 'a'), (3, 'd')]
```

この例では、`3`の値を持つ2つの要素 `(3, 'a')` と `(3, 'd')` の相対的な順序は、ソート前と後で変わっていません。

#### 不安定なソート後 (数値でソート)
```
[(1, 'b'), (2, 'c'), (3, 'd'), (3, 'a')]
```

不安定なソートでは、`3`の値を持つ要素の相対的な順序がソート前後で変わってしまっています。

安定なソートは、特に複数のキーでソートする際に重要です。たとえば、最初に名前でソートし、その後年齢でソートする場合、安定なソートを使用することで、同じ年齢の人々の名前の順序が保たれます。

---

SortedFunc と SortedStableFunc の実装を見ても Sort の実装方法が異なるので、期待するふるまいとしては差分にあるような taple 型の配列において a で sort した結果、SortedFunc では b の値の順序が保証されず、SortedStableFunc では b の順序は保証される、ということでした。

ただ、結果としてはどちらのメソッドも順序が保証されてしまっており、若干期待するふるまいとは違う挙動をしていました。

結果は https://go.dev/play/p/ePGk-95Z8EW で簡単に確認できます。taple1 の結果は毎回ばらばらになってほしいんですが固定されてしまっていました。